### PR TITLE
Fixing task element overwrite on multiple task rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -408,7 +408,7 @@ function loadMatrix(matDate) {
 
     const fDate = dateFormat(matDate);
 
-    dayHeader.innerHTML = `
+    dayHeader.innerHTML += `
             <button type="button">+</button>
             <span class="day-name">${day} (${fDate})</span>
         `;


### PR DESCRIPTION
When the matrix has to display multiple tasks on the same day, the current code in the develop branch overwrites the previous HTML content. 

This code fixes it by keeping the HTML for the previous task element and adding the next task element on top of it.

Replaced `=` with `+=` _(see changes made)_