### PR TITLE
Fix week change when navigating out of pages

### DIFF
--- a/main.js
+++ b/main.js
@@ -609,6 +609,7 @@ function goToMonth(month) {
   document.getElementById('months-dropdown').style.display = 'none';
   deleteChild();
   date.setMonth(month);
+  date.setDate(1);
   loadMatrix(date);
 }
 
@@ -802,11 +803,15 @@ function openCategoryPage() {
   header.style.display = 'none';
 }
 
+function giveToday() {
+  const today = new Date();
+  return today;
+}
 // eslint-disable-next-line no-unused-vars
 function backFromCategory() {
   categoryPage.style.display = 'none';
   header.style.display = 'block';
-  loadMatrix(date);
+  loadMatrix(giveToday());
   matrix.style.display = 'block';
 }
 
@@ -925,7 +930,7 @@ function getDayDate() {
 function backFromChecklist() {
   checklistPage.innerHTML = '';
   checklistPage.style.display = 'none';
-  loadMatrix(date);
+  loadMatrix(giveToday());
   header.style.display = 'block';
   matrix.style.display = 'block';
 }


### PR DESCRIPTION
On navigating out of the category page and the checklist page, or on changing the month using the dropdown menu, the week of the matrix gets changed. This is because the `loadMatrix()` function places the date object on the next Sunday when rendering task elements.

This bug fix fixes this issue by assigning a new date object with the current date and then calling the `loadMatrix()` function.

On changing the month using the dropdown menu, changes were made to set the date to the first date of the month so it displays the month from the start.