### PR TITLE
Fix checkbox click on opening task description + completion status store

### DIFF
--- a/main.js
+++ b/main.js
@@ -433,10 +433,14 @@ function loadMatrix(matDate) {
               const id = `${fDate}-${task.taskName}`;
 
               taskList.innerHTML += `
-                <div id="${id}-ele" class="task-element">
-                  <label class="checkbox-label" for="${id}-checkbox"${id}-task"> ${task.taskName} </label>
-                  <input type="checkbox" id="${id}-checkbox" name="task-checkbox" value="checked" onchange="checkboxStore('${id}')">
-                </div>
+                <div class="name-and-checkbox">
+                  <div id="${id}-ele" class="task-element checkbox-label">
+                    <p class="checkbox-label"> ${task.taskName} </label>
+                  </div>
+                  <div class="checkbox">
+                    <input type="checkbox" id="${id}-checkbox" name="task-checkbox" value="checked" onchange="checkboxStore('${id}')">
+                  </div>
+                <div>
               `;
 
               // Get id of checkboxes to be ticked
@@ -544,7 +548,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // eslint-disable-next-line no-unused-vars
 function checkboxStore(id) {
   const boxDate = id.slice(0, 10);
-  const boxName = id.slice(11, -9);
+  const boxName = id.slice(11);
 
   jsonObj.forEach((category) => {
     category.activityTypes.forEach((activityType) => {

--- a/style.css
+++ b/style.css
@@ -214,6 +214,22 @@ body {
     border-width: 0.1rem;
 }
 
+.name-and-checkbox {
+    display: flex;
+    justify-content: space-between;
+}
+
+.checkbox-label {
+    width: 97%;
+}
+
+.checkbox {
+    width: 3%;
+    justify-content: center;
+    border-bottom: solid;
+    border-width: 0.1rem;
+}
+
 #category-page {
     background: #f0f8ff;
     padding: 20px;


### PR DESCRIPTION
In the develop branch, when the task element is clicked to open the task description page, the checkbox is also ticked because they both belong to the same division to which the onclick is set.

This bug fix fixes that issue by assigning separate divisions for the checkbox and its label (task name) and setting different onclick functions

It also addresses improper slicing of the checkbox id to get its name and date.