### PR TITLE
Disable editing stray category and activity name

### DIFF
--- a/main.js
+++ b/main.js
@@ -129,6 +129,10 @@ function openDetail(id) {
       });
     });
 
+    // Give taskDesc a placeholder so it is clickable
+    if (taskDesc === '') {
+      taskDesc = '---';
+    }
     const overlayDesc = document.createElement('div');
     // Class overlays on top of all elements
     overlayDesc.classList.add('overlay');
@@ -349,7 +353,6 @@ function editDesc(id, element) {
       category.activityTypes.forEach((activityType) => {
         activityType.Tasks.forEach((task) => {
           if (task.taskName === taskName) {
-            console.log(category.categoryName.trim() + activityType.activityName);
             if (category.categoryName.trim() === 'Stray category' || activityType.activityName.trim() === 'Stray activity') {
               isStray = true;
             }

--- a/main.js
+++ b/main.js
@@ -305,6 +305,9 @@ function deleteDate(id) {
 // Click on task description items to edit them using entry boxes and date inputs
 // eslint-disable-next-line no-unused-vars
 function editDesc(id, element) {
+  const taskDate = id.slice(0, 10);
+  const taskName = id.slice(11);
+
   let boxId = id;
   let textBox = null;
 
@@ -338,6 +341,25 @@ function editDesc(id, element) {
     default:
       textBox = '';
       break;
+  }
+
+  let isStray = false;
+  if (element === 'category' || element === 'activity') {
+    jsonObj.forEach((category) => {
+      category.activityTypes.forEach((activityType) => {
+        activityType.Tasks.forEach((task) => {
+          if (task.taskName === taskName) {
+            console.log(category.categoryName.trim() + activityType.activityName);
+            if (category.categoryName.trim() === 'Stray category' || activityType.activityName.trim() === 'Stray activity') {
+              isStray = true;
+            }
+          }
+        });
+      });
+    });
+  }
+  if (isStray) {
+    return;
   }
 
   // Entry box to replace the text


### PR DESCRIPTION
Stray tasks (tasks without category and activity) are added to the JSON file by using their name ("Stray category"). Therefore, no changes should be made to the stray category's name. This feature checks if a click target element is stray category before allowing the user to edit it.