### PR TITLE
Four week display

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,9 @@
 
         <div id="mobile-table" class="mobile-table">
         </div>
+
+        <div id="desktop-container" class="four-week">
+        </div>
     </section>
 
     <section id="category-page">

--- a/main.js
+++ b/main.js
@@ -486,6 +486,8 @@ function loadMatrix(matDate) {
                   // Appending now so the division can be checked for existence - prevent duplicates
                   dayDiv.appendChild(taskList);
                   daysContainer.appendChild(dayDiv);
+                  matrixContainer.appendChild(daysContainer);
+                  matrix.appendChild(matrixContainer);
                 }
 
                 // Get id of checkboxes to be ticked

--- a/main.js
+++ b/main.js
@@ -378,7 +378,31 @@ function backFromDesc() {
   descWin.remove();
 }
 
+let renderedWeeks = 1;
 function loadMatrix(matDate) {
+  let daysContainer = document.getElementById('mobile-table');
+  let bigScreen = false;
+  const matrixContainer = document.createElement('div');
+  if (window.screen.width > 1000) {
+    bigScreen = true;
+    daysContainer = document.createElement('div');
+    switch (renderedWeeks) {
+      case 1:
+        matDate.setDate(1);
+        break;
+      case 2:
+        matDate.setDate(8);
+        break;
+      case 3:
+        matDate.setDate(15);
+        break;
+      case 4:
+        matDate.setDate(22);
+        break;
+      default:
+    }
+  }
+
   setMonthName(matDate);
   const dayNum = matDate.getDay();
 
@@ -387,7 +411,6 @@ function loadMatrix(matDate) {
 
   const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-  const daysContainer = document.getElementById('mobile-table');
   daysContainer.innerHTML = '';
 
   // jsonString = localStorage.getItem('taskData');
@@ -461,12 +484,22 @@ function loadMatrix(matDate) {
       });
     }
     daysContainer.appendChild(dayDiv);
+
     // Tick all checkboxes that have a completion date in json.
     boxToTick.forEach((boxId) => {
       document.getElementById(`${boxId}`).checked = true;
     });
   });
   setListen();
+  if (bigScreen) {
+    daysContainer.setAttribute('id', `table-${renderedWeeks}`);
+    matrixContainer.appendChild(daysContainer);
+    if (renderedWeeks < 4) {
+      renderedWeeks += 1;
+      loadMatrix(matDate);
+    }
+  }
+  matrix.appendChild(daysContainer);
 }
 
 function addToDate(toDate) {

--- a/main.js
+++ b/main.js
@@ -382,10 +382,11 @@ let renderedWeeks = 1;
 function loadMatrix(matDate) {
   let daysContainer = document.getElementById('mobile-table');
   let bigScreen = false;
-  const matrixContainer = document.createElement('div');
+  const matrixContainer = document.getElementById('desktop-container');
   if (window.screen.width > 1000) {
     bigScreen = true;
     daysContainer = document.createElement('div');
+    daysContainer.classList.add('desktop-days');
     switch (renderedWeeks) {
       case 1:
         matDate.setDate(1);
@@ -484,7 +485,7 @@ function loadMatrix(matDate) {
       });
     }
     daysContainer.appendChild(dayDiv);
-
+    // matrixContainer.appendChild(daysContainer);
     // Tick all checkboxes that have a completion date in json.
     boxToTick.forEach((boxId) => {
       document.getElementById(`${boxId}`).checked = true;
@@ -499,7 +500,7 @@ function loadMatrix(matDate) {
       loadMatrix(matDate);
     }
   }
-  matrix.appendChild(daysContainer);
+  matrix.appendChild(matrixContainer);
 }
 
 function addToDate(toDate) {

--- a/main.js
+++ b/main.js
@@ -378,16 +378,28 @@ function backFromDesc() {
   descWin.remove();
 }
 
-let renderedWeeks = 1;
+let renderedWeek = 1;
+let bigScreen = false;
+
 function loadMatrix(matDate) {
   let daysContainer = document.getElementById('mobile-table');
-  let bigScreen = false;
+  bigScreen = false;
   const matrixContainer = document.getElementById('desktop-container');
   if (window.screen.width > 1000) {
     bigScreen = true;
+    if (renderedWeek === 1) {
+      matrixContainer.innerHTML = '';
+    }
     daysContainer = document.createElement('div');
     daysContainer.classList.add('desktop-days');
-    switch (renderedWeeks) {
+
+    const weekLabel = document.createElement('div');
+    weekLabel.classList.add('week-label');
+    weekLabel.textContent = `week ${renderedWeek}`;
+
+    daysContainer.appendChild(weekLabel);
+
+    switch (renderedWeek) {
       case 1:
         matDate.setDate(1);
         break;
@@ -412,10 +424,14 @@ function loadMatrix(matDate) {
 
   const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-  daysContainer.innerHTML = '';
-
-  // jsonString = localStorage.getItem('taskData');
-  // jsonObj = JSON.parse(jsonString);
+  /*
+    On mobiles, daysContainer is the only column. So on every loadMatrix() call, it must be cleared
+    so data doesn't overlap. On desktops, daysContatiner will have a week label on top
+    so clearing it will delete the week label too.
+  */
+  if (!bigScreen) {
+    daysContainer.innerHTML = '';
+  }
 
   daysOfWeek.forEach((day) => {
     const dayDiv = document.createElement('div');
@@ -485,22 +501,26 @@ function loadMatrix(matDate) {
       });
     }
     daysContainer.appendChild(dayDiv);
-    // matrixContainer.appendChild(daysContainer);
+
     // Tick all checkboxes that have a completion date in json.
     boxToTick.forEach((boxId) => {
       document.getElementById(`${boxId}`).checked = true;
     });
   });
-  setListen();
+
   if (bigScreen) {
-    daysContainer.setAttribute('id', `table-${renderedWeeks}`);
+    daysContainer.setAttribute('id', `table-${renderedWeek}`);
     matrixContainer.appendChild(daysContainer);
-    if (renderedWeeks < 4) {
-      renderedWeeks += 1;
+    if (renderedWeek < 4) {
+      renderedWeek += 1;
       loadMatrix(matDate);
+    } else {
+      renderedWeek = 1;
     }
   }
   matrix.appendChild(matrixContainer);
+
+  setListen();
 }
 
 function addToDate(toDate) {
@@ -741,7 +761,11 @@ function prevMonth() {
     Creating the matrix puts the date on next Sunday
     so decrement 8 to get to previous week
   */
-  date.setDate(date.getDate() - 8);
+  if (bigScreen) {
+    date.setMonth(date.getMonth() - 1);
+  } else {
+    date.setDate(date.getDate() - 8);
+  }
 
   loadMatrix(date);
 }
@@ -750,7 +774,9 @@ function prevMonth() {
 function nextMonth() {
   deleteChild();
   // Don't have to increment date as creating matrix puts date on next week
-
+  if (bigScreen) {
+    date.setMonth(date.getMonth() + 1);
+  }
   loadMatrix(date);
 }
 

--- a/style.css
+++ b/style.css
@@ -180,6 +180,12 @@ body {
     width: 100%;
 }
 
+.week-label {
+    text-align: center;
+    background-color: #ece3e3;
+    margin: 1rem 0rem;
+}
+
 .four-week {
     display: flex;
     width: 99%;

--- a/style.css
+++ b/style.css
@@ -176,6 +176,20 @@ body {
     margin: 0rem 0.2rem;
 }
 
+#matrix{
+    width: 100%;
+}
+
+.four-week {
+    display: flex;
+    width: 99%;
+    justify-content: space-between;
+}
+
+.desktop-days {
+    width: 23%;
+
+}
 .dropdown {
     position: relative;
     display: inline-block;
@@ -242,6 +256,7 @@ body {
 
 .checkbox-label {
     width: 97%;
+    overflow: hidden;
 }
 
 .checkbox {


### PR DESCRIPTION
The screen width of the machine is read and if it is above a certain threshold, the website now displays four weeks in columns instead of just one. The next/previous week buttons are now configured to work for switching months. All other functionalities remain the same. 