### PR TITLE
Fixed task description page error for tasks with hyphen(-) in their name

### DIFF
--- a/main.js
+++ b/main.js
@@ -107,10 +107,10 @@ function giveDay(iDate) {
 function openDetail(id) {
   if (document.getElementById('detailed-desc') == null) {
     // id format -> taskDate-taskName
+
     const taskDate = id.slice(0, 10);
 
-    const taskName = id.slice(11).split('-')[0];
-
+    const taskName = id.slice(11);
     const detailId = `${taskDate}-${taskName}`;
 
     // To check for due date with day as well


### PR DESCRIPTION
The error occurred because of the way that the name of the task is extracted from the element's ID. It previously used hyphens to split the id into respective fields but this method is no longer necessary as the name stretches to the end of the id without any other trailing elements